### PR TITLE
CI/CD - Adding Release Workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
         run: |
           npm install
           npm run build
-          zip -r build.zip build/*
+          zip -r build.zip build/
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1


### PR DESCRIPTION
Releases will now be uploaded to the releases tab on push to master. spendy.zip will include the prebuilt folder necessary for installation.
![image](https://user-images.githubusercontent.com/55668495/148667642-0a0d027e-c511-470e-ab47-3fca55968123.png)
